### PR TITLE
Added definition of the terms hacker and hacking, for clarrifying the goals of the organisation

### DIFF
--- a/rules-of-the-association.md
+++ b/rules-of-the-association.md
@@ -200,6 +200,10 @@ In these Rules-
 
 **general meeting** means a general meeting of the members of the Association convened in accordance with Part 4 and includes an annual general meeting, a special general meeting and a disciplinary appeal meeting;
 
+**hacker** means a person who creates, makes, tinkers or otherwise legally modifies  software, hardware, building materials or engages in other creative outlets. It specifically does not apply to illegal activity.
+
+**hacking** is the act of performing the mentioned tasks of a hacker. The Ballarat Hackerspace does not use this term to refer to the illegal access of data or computer systems.
+
 **member** means a member of the Association;
 
 **member entitled to vote** means a member who under rule 13(2) is entitled to vote at a general meeting;

--- a/rules-of-the-association.md
+++ b/rules-of-the-association.md
@@ -2,7 +2,7 @@
 
 ## Associations Incorporation Reform Act 2012
 
-# MODEL RULES
+# RULES OF THE ASSOCIATION BALLARAT HACKERSPACE
 
 ### For an
 


### PR DESCRIPTION

** DO NOT MERGE UNTIL AFTER THE MEETING ON APRIL 1ST. THIS IS NOT A JOKE **

Updates the rules to address the concerns of the ACNC regarding bhack becoming a charity. The main points of contention were that the term hacker is not defined and the space can be used for commercial purposes, removing its "public good" status